### PR TITLE
Convert gitlab_github_migration/dryrun_check to GitHub Actions

### DIFF
--- a/.github/workflows/dryrun_check.yml
+++ b/.github/workflows/dryrun_check.yml
@@ -1,0 +1,56 @@
+name: gitlab_github_migration/dryrun_check
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  build-job:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Compiling the code..."
+    - run: echo "Compile complete."
+  unit-test-job:
+    needs: build-job
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Running unit tests... This will take about 60 seconds."
+    - run: sleep 60
+    - run: echo "Code coverage is 90%"
+  lint-test-job:
+    needs: build-job
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Linting code... This will take about 10 seconds."
+    - run: sleep 10
+    - run: echo "No lint issues found."
+  deploy-job:
+    needs:
+    - unit-test-job
+    - lint-test-job
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Deploying application..."
+    - run: echo "Application successfully deployed."


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/gitlab_github_migration/dryrun_check) :tada:

## Manual steps

Perform the following steps to complete the migration:

### gitlab_github_migration/dryrun_check
- [ ] Ensure an environment with the name '`production`' exists by following these [instructions](https://docs.github.com/en/actions/reference/environments#required-reviewers).